### PR TITLE
Home board topic

### DIFF
--- a/src/main/java/shop/mtcoding/jobara/controller/BoardController.java
+++ b/src/main/java/shop/mtcoding/jobara/controller/BoardController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
 import shop.mtcoding.jobara.dto.board.BoardResp.BoardDetailRespDto;
+import shop.mtcoding.jobara.dto.board.BoardResp.BoardListRespDto;
 import shop.mtcoding.jobara.dto.board.BoardResp.BoardMainRespDto;
 import shop.mtcoding.jobara.service.BoardService;
 
@@ -19,7 +20,9 @@ public class BoardController {
       private BoardService boardService;
 
       @GetMapping({ "/", "/home" })
-      public String home() {
+      public String home(Model model) {
+            List<BoardMainRespDto> boardListPS = boardService.getListToMain();
+            model.addAttribute("boardMainList", boardListPS);
             return "board/home";
       }
 
@@ -32,7 +35,7 @@ public class BoardController {
 
       @GetMapping("/board/list")
       public String list(Model model) {
-            List<BoardMainRespDto> boardListPS = boardService.getList();
+            List<BoardListRespDto> boardListPS = boardService.getList();
             model.addAttribute("boardList", boardListPS);
             return "board/list";
       }

--- a/src/main/java/shop/mtcoding/jobara/dto/board/BoardResp.java
+++ b/src/main/java/shop/mtcoding/jobara/dto/board/BoardResp.java
@@ -6,6 +6,15 @@ import lombok.Setter;
 public class BoardResp {
     @Getter
     @Setter
+    public static class BoardListRespDto {
+        private Integer id;
+        private String title;
+        private String companyName;
+        private Integer companyId;
+    }
+
+    @Getter
+    @Setter
     public static class BoardMainRespDto {
         private Integer id;
         private String title;

--- a/src/main/java/shop/mtcoding/jobara/model/BoardRepository.java
+++ b/src/main/java/shop/mtcoding/jobara/model/BoardRepository.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 
 import shop.mtcoding.jobara.dto.board.BoardResp.BoardDetailRespDto;
+import shop.mtcoding.jobara.dto.board.BoardResp.BoardListRespDto;
 import shop.mtcoding.jobara.dto.board.BoardResp.BoardMainRespDto;
 
 @Mapper
@@ -12,7 +13,9 @@ public interface BoardRepository {
 
     public List<Board> findAll();
 
-    public List<BoardMainRespDto> findAllWithCompany();
+    public List<BoardMainRespDto> findAllWithCompanyToMain();
+
+    public List<BoardListRespDto> findAllWithCompany();
 
     public BoardDetailRespDto findByIdWithCompany(int boardId);
 

--- a/src/main/java/shop/mtcoding/jobara/service/BoardService.java
+++ b/src/main/java/shop/mtcoding/jobara/service/BoardService.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import shop.mtcoding.jobara.dto.board.BoardResp.BoardDetailRespDto;
+import shop.mtcoding.jobara.dto.board.BoardResp.BoardListRespDto;
 import shop.mtcoding.jobara.dto.board.BoardResp.BoardMainRespDto;
 import shop.mtcoding.jobara.ex.CustomException;
 import shop.mtcoding.jobara.model.BoardRepository;
@@ -18,6 +19,19 @@ public class BoardService {
 
     @Autowired
     private BoardRepository boardRepository;
+
+    public List<BoardMainRespDto> getListToMain() {
+
+        List<BoardMainRespDto> boardListPS;
+
+        try {
+            boardListPS = boardRepository.findAllWithCompanyToMain();
+        } catch (Exception e) {
+            throw new CustomException("서버에 일시적인 문제가 생겼습니다", HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+
+        return boardListPS;
+    }
 
     public BoardDetailRespDto getDetail(int id) {
         BoardDetailRespDto boardDetailPS;
@@ -31,8 +45,8 @@ public class BoardService {
         return boardDetailPS;
     }
 
-    public List<BoardMainRespDto> getList() {
-        List<BoardMainRespDto> boardListPS;
+    public List<BoardListRespDto> getList() {
+        List<BoardListRespDto> boardListPS;
 
         try {
             boardListPS = boardRepository.findAllWithCompany();

--- a/src/main/resources/db/data.sql
+++ b/src/main/resources/db/data.sql
@@ -5,5 +5,6 @@ insert into company_tb(username, password, email, address, detail_address, tel, 
 insert into board_tb(company_id, title, content, career, created_at) values(1, '공고제목1','공고내용1', 1, now());
 insert into board_tb(company_id, title, content, career, created_at) values(1, '공고제목2','공고내용2', 2, now());
 insert into board_tb(company_id, title, content, career, created_at) values(1, '공고제목3','공고내용3', 4, now());
+insert into board_tb(company_id, title, content, career, created_at) values(1, '공고제목4','공고내용4', 3, now());
 
 commit; 

--- a/src/main/resources/mapper/board.xml
+++ b/src/main/resources/mapper/board.xml
@@ -9,7 +9,14 @@
         select * from board_tb
     </select>
 
-    <select id="findAllWithCompany" resultType="shop.mtcoding.jobara.dto.board.BoardResp$BoardMainRespDto">
+    <select id="findAllWithCompanyToMain" resultType="shop.mtcoding.jobara.dto.board.BoardResp$BoardMainRespDto">
+        SELECT bt.id, bt.title, ct.company_name, ct.id company_id FROM BOARD_TB bt
+        inner join company_tb ct
+        on bt.company_id = ct.id
+        limit 4
+    </select>
+
+    <select id="findAllWithCompany" resultType="shop.mtcoding.jobara.dto.board.BoardResp$BoardListRespDto">
         SELECT bt.id, bt.title, ct.company_name, ct.id company_id FROM BOARD_TB bt
         inner join company_tb ct
         on bt.company_id = ct.id

--- a/src/main/webapp/WEB-INF/view/board/home.jsp
+++ b/src/main/webapp/WEB-INF/view/board/home.jsp
@@ -4,122 +4,76 @@
 
         <div class="container my-3 py-3 px-3">
             <div class="row">
-                <div id="mainImage1" class="col d-flex justify-content-center" onmouseenter="mouseEnterImages(this)"
-                    onmouseleave="mouseLeaveImages(this)">
+                <div id="mainImage1" class="col d-flex justify-content-center" onmouseenter="popularEnterImages(this)"
+                    onmouseleave="popularLeaveImages(this)">
                     <img src="/images/newjeans.jpg" class="img-thumbnail" alt="Cinque Terre">
                 </div>
-                <div id="mainImage2" class="col d-flex justify-content-center" onmouseenter="mouseEnterImages(this)"
-                    onmouseleave="mouseLeaveImages(this)">
+                <div id="mainImage2" class="col d-flex justify-content-center" onmouseenter="popularEnterImages(this)"
+                    onmouseleave="popularLeaveImages(this)">
                     <img src="/images/newjeans.jpg" class="img-thumbnail" alt="Cinque Terre">
                 </div>
-                <div id="mainImage3" class="col d-flex justify-content-center" onmouseenter="mouseEnterImages(this)"
-                    onmouseleave="mouseLeaveImages(this)">
+                <div id="mainImage3" class="col d-flex justify-content-center" onmouseenter="popularEnterImages(this)"
+                    onmouseleave="popularLeaveImages(this)">
                     <img src="/images/newjeans.jpg" class="img-thumbnail" alt="Cinque Terre">
                 </div>
             </div>
             <div>
                 <!-- 카드 들어갈 곳 -->
                 <div class="row">
+
+                    <c:forEach items="${boardMainList}" var="board">
                     <div class="col-md-3 py-2">
-                        <div class="card col-lg-12">
-                            <img class="card-img-top" style="height: 100px;" src="/images/newjeans.jpg"
-                                alt="Card image">
-                            <div class="card-body">
-                                <div class="my-text-ellipsis">
-                                    <h5>(주)엘지</h5>
+                        <a href="/board/${board.id}" class="no_under_line_link">
+                            <div id="boardImage-${board.id}" class="card col-lg-12"
+                                onmouseenter="boardEnterImages(this)" onmouseleave="boardLeaveImages(this)">
+                                <img class="card-img-top" style="height: 100px;" src="/images/newjeans.jpg"
+                                    alt="Card image">
+                                <div class="card-body">
+                                    <div class="my-text-ellipsis">
+                                        <h5>${board.companyName}</h5>
+                                    </div>
+                                    <div class="my-text-ellipsis">
+                                        ${board.title}
+                                    </div>
+                                    <div class="my-text-ellipsis">
+                                        채용
+                                    </div>
                                 </div>
-                                <div class="my-text-ellipsis">
-                                    2023년 IT직 경력/신입
-                                </div>
-                                <div class="my-text-ellipsis">
-                                    채용
-                                </div>
-                            </div>
-                            <div class="card-footer d-flex justify-content-between">
-                                <div>(D-1)</div>
-                                <div><i id="heart" class="fa-regular fa-heart my-xl my-cursor fa-lg"></i></div>
-                            </div>
+                        </a>
+                        <div class="card-footer d-flex justify-content-between">
+                            <div>(D-1)</div>
+                            <div><i id="heart" class="fa-regular fa-heart my-xl my-cursor fa-lg"></i></div>
                         </div>
                     </div>
-                    <div class="col-md-3 py-2">
-                        <div class="card col-lg-12">
-                            <img class="card-img-top" style="height: 100px;" src="/images/newjeans.jpg"
-                                alt="Card image">
-                            <div class="card-body">
-                                <div class="my-text-ellipsis">
-                                    <h5>(주)엘지</h5>
-                                </div>
-                                <div class="my-text-ellipsis">
-                                    2023년 IT직 경력/신입
-                                </div>
-                                <div class="my-text-ellipsis">
-                                    채용
-                                </div>
-                            </div>
-                            <div class="card-footer d-flex justify-content-between">
-                                <div>(D-1)</div>
-                                <div><i id="heart" class="fa-regular fa-heart my-xl my-cursor fa-lg"></i></div>
-                            </div>
-                        </div>
                     </div>
-                    <div class="col-md-3 py-2">
-                        <div class="card col-lg-12">
-                            <img class="card-img-top" style="height: 100px;" src="/images/newjeans.jpg"
-                                alt="Card image">
-                            <div class="card-body">
-                                <div class="my-text-ellipsis">
-                                    <h5>(주)엘지</h5>
-                                </div>
-                                <div class="my-text-ellipsis">
-                                    2023년 IT직 경력/신입
-                                </div>
-                                <div class="my-text-ellipsis">
-                                    채용
-                                </div>
-                            </div>
-                            <div class="card-footer d-flex justify-content-between">
-                                <div>(D-1)</div>
-                                <div><i id="heart" class="fa-regular fa-heart my-xl my-cursor fa-lg"></i></div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="col-md-3 py-2">
-                        <div class="card col-lg-12">
-                            <img class="card-img-top" style="height: 100px;" src="/images/newjeans.jpg"
-                                alt="Card image">
-                            <div class="card-body">
-                                <div class="my-text-ellipsis">
-                                    <h5>(주)엘지</h5>
-                                </div>
-                                <div class="my-text-ellipsis">
-                                    2023년 IT직 경력/신입
-                                </div>
-                                <div class="my-text-ellipsis">
-                                    채용
-                                </div>
-                            </div>
-                            <div class="card-footer d-flex justify-content-between">
-                                <div>(D-1)</div>
-                                <div><i id="heart" class="fa-regular fa-heart my-xl my-cursor fa-lg"></i></div>
-                            </div>
-                        </div>
-                    </div>
+                    </c:forEach>
+
+                  
                 </div>
             </div>
         </div>
+
         <script>
-            function mouseEnterImages(e) {
+            function popularEnterImages(e) {
                 console.log(e.getAttribute('id'));
                 let id = e.getAttribute('id');
                 $("#" + id).removeClass("col");
                 $("#" + id).addClass("col-6");
             }
-
-            function mouseLeaveImages(e) {
+            function popularLeaveImages(e) {
                 console.log(e.getAttribute('id'));
                 let id = e.getAttribute('id');
                 $("#" + id).removeClass("col-6");
                 $("#" + id).addClass("col");
+            }
+
+            function boardEnterImages(e) {
+                let id = e.getAttribute('id');
+                $("#" + id).addClass("border border-primary");
+            }
+            function boardLeaveImages(e) {
+                let id = e.getAttribute('id');
+                $("#" + id).removeClass("border border-primary");
             }
         </script>
 

--- a/src/test/java/shop/mtcoding/jobara/controller/BoardControllerTest.java
+++ b/src/test/java/shop/mtcoding/jobara/controller/BoardControllerTest.java
@@ -23,7 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import shop.mtcoding.jobara.dto.board.BoardResp.BoardDetailRespDto;
-import shop.mtcoding.jobara.dto.board.BoardResp.BoardMainRespDto;
+import shop.mtcoding.jobara.dto.board.BoardResp.BoardListRespDto;
 import shop.mtcoding.jobara.model.User;
 
 @Transactional
@@ -81,7 +81,7 @@ public class BoardControllerTest {
                 get("/board/list"));
 
         Map<String, Object> map = resultActions.andReturn().getModelAndView().getModel();
-        List<BoardMainRespDto> boardList = (List<BoardMainRespDto>) map.get("boardList");
+        List<BoardListRespDto> boardList = (List<BoardListRespDto>) map.get("boardList");
 
         // String model = om.writeValueAsString(boardList);
         // System.out.println("테스트 : " + model);

--- a/src/test/java/shop/mtcoding/jobara/controller/BoardControllerTest.java
+++ b/src/test/java/shop/mtcoding/jobara/controller/BoardControllerTest.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import shop.mtcoding.jobara.dto.board.BoardResp.BoardDetailRespDto;
 import shop.mtcoding.jobara.dto.board.BoardResp.BoardListRespDto;
+import shop.mtcoding.jobara.dto.board.BoardResp.BoardMainRespDto;
 import shop.mtcoding.jobara.model.User;
 
 @Transactional
@@ -82,6 +83,26 @@ public class BoardControllerTest {
 
         Map<String, Object> map = resultActions.andReturn().getModelAndView().getModel();
         List<BoardListRespDto> boardList = (List<BoardListRespDto>) map.get("boardList");
+
+        // String model = om.writeValueAsString(boardList);
+        // System.out.println("테스트 : " + model);
+
+        // then
+        resultActions.andExpect(status().isOk());
+        assertThat(boardList.get(1).getTitle()).isEqualTo("공고제목2");
+        assertThat(boardList.get(2).getTitle()).isEqualTo("공고제목3");
+    }
+
+    @Test
+    public void boardMainList_test() throws Exception {
+        // given
+
+        // when
+        ResultActions resultActions = mvc.perform(
+                get("/"));
+
+        Map<String, Object> map = resultActions.andReturn().getModelAndView().getModel();
+        List<BoardMainRespDto> boardList = (List<BoardMainRespDto>) map.get("boardMainList");
 
         // String model = om.writeValueAsString(boardList);
         // System.out.println("테스트 : " + model);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/122352251/221069127-08d289e9-0af2-4af2-9933-65cd09fe4354.png)

1. 구현
- Main 페이지 하단 공고 목록 뿌리기 (limit 4)
- Main 페이지에 Data를 뿌리기 위한 Controller, Service, Repository, mapper, View 구현

2. 테스트
- 통합 테스트 (이전 공고 목록보기 페이지와 동일한 로직 사용)

특이사항 : x
